### PR TITLE
Restore screen size to SIZE_SCREEN_ORIGINAL

### DIFF
--- a/src/CapAndHomalg.jl
+++ b/src/CapAndHomalg.jl
@@ -214,6 +214,7 @@ function __init__()
         println("Type: ?CapAndHomalg for more information")
     end
 
+    SizeScreen(SIZE_SCREEN_ORIGINAL)
 end
 
 """


### PR DESCRIPTION
Changing the screen size to 2^12 affects all other Julia code loading GAP
packages. So be a nice citizen and cleanup after ourselves.
