### PR TITLE
CI: update codecov/codecov-action to v2

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -48,4 +48,4 @@ jobs:
         uses: julia-actions/julia-processcoverage@v1
 
       - name: "Upload to codecov.io"
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2


### PR DESCRIPTION
v1 will be disabled February 1, 2022; see https://github.com/codecov/codecov-action
